### PR TITLE
Fix null reference exception when calling TryResolveFunction with unknown symbol

### DIFF
--- a/Unity/SymbolResolver.cs
+++ b/Unity/SymbolResolver.cs
@@ -32,6 +32,11 @@ namespace Unity
             where T : Delegate
         {
             var address = GetAddressOrZero(name);
+            if (address == IntPtr.Zero)
+            {
+                del = null;
+                return false;
+            }
             del = Marshal.GetDelegateForFunctionPointer<T>(address);
             return del != null;
         }


### PR DESCRIPTION
Marshal.GetDelegateForFunctionPointer throws a null reference exception when called with a zero value IntPtr
```
System.ArgumentNullException: Value cannot be null.
Parameter name: ptr
   at System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer(IntPtr ptr, Type t)
   at System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer[TDelegate](IntPtr ptr)
   at Unity.SymbolResolver.TryResolveFunction[T](String name, T& del)
   at Unity.SymbolResolver.ResolveFunction[T](String name)
   at TypeTreeDumper.EntryPoint.Dump()
```