### PR TITLE
Remove IsMainThread

### DIFF
--- a/TypeTreeDumper.Client/EntryPoint.cs
+++ b/TypeTreeDumper.Client/EntryPoint.cs
@@ -26,12 +26,6 @@ namespace TypeTreeDumper
         static UnityVersionDelegate ParseUnityVersion;
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        [return: MarshalAs(UnmanagedType.U1)]
-        delegate bool IsMainThreadDelegate();
-
-        static IsMainThreadDelegate IsMainThread;
-
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         delegate IntPtr GetUnityVersionDelegate();
 
         static GetUnityVersionDelegate GetUnityVersion;
@@ -65,7 +59,7 @@ namespace TypeTreeDumper
                         Thread.Sleep(500);
                     }
 
-                    server.WriteLine($"Engine loaded. IsMainThread {IsMainThread()}");
+                    server.WriteLine($"Engine loaded.");
                 }
             }
             catch(Exception ex)
@@ -116,19 +110,7 @@ namespace TypeTreeDumper
                 }
 
                 ParseUnityVersion(out UnityVersion version, Marshal.PtrToStringAnsi(GetUnityVersion()));
-                server.WriteLine($"UnityVersion {version}");
-                if (version >= UnityVersion.Unity2018_1)
-                {
-                    IsMainThread = resolver.ResolveFunction<IsMainThreadDelegate>("?CurrentThreadIsMainThread@@YA_NXZ");
-                }
-                else if (version >= UnityVersion.Unity2018_4)
-                {
-                    IsMainThread = resolver.ResolveFunction<IsMainThreadDelegate>("?IsMainThread@CurrentThread@@YA_NXZ");
-                }  else
-                {
-                    IsMainThread = () => false;
-                }
-                server.WriteLine($"Starting export. IsMainThread {IsMainThread()}");
+                server.WriteLine($"Starting export. UnityVersion {version}");
                 var engine = new UnityEngine(version, resolver);
                 ExportStringData(engine);
                 ExportClassesJson(engine);


### PR DESCRIPTION
IsMainThread does not appear to be available for versions of unity below 2018. `?CurrentThreadIsMainThread@@YA_NXZ` is not available on 2018.1.0 and so now throws an exception when trying to access, `?InternalEditorUtility_CUSTOM_CurrentThreadIsMainThread@@YAEXZ` or `?Object_CUSTOM_CurrentThreadIsMainThread@@YAEXZ` would need to be used instead. 

As its not needed, it may as well be removed.