### PR TITLE
Add GetUnityVersion support for Unity 5.4 and lower

### DIFF
--- a/Unity/UnityVersion.cs
+++ b/Unity/UnityVersion.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.RegularExpressions;
 
 namespace Unity
 {
@@ -73,6 +74,20 @@ namespace Unity
             Patch = patch;
             Type  = type;
             Build = build;
+        }
+
+        public UnityVersion(string version)
+        {
+            var match = Regex.Match(version, @"(\d+)\.(\d+)\.(\d+)([abfpx])(\d+)");
+            if (!match.Success)
+            {
+                throw new ArgumentException($"Invalid version: {version}");
+            }
+            Major = int.Parse(match.Groups[1].Value);
+            Minor = int.Parse(match.Groups[2].Value);
+            Patch = int.Parse(match.Groups[3].Value);
+            Type = VersionTypeFromChar(match.Groups[4].Value[0]);
+            Build = int.Parse(match.Groups[5].Value);
         }
 
         public int CompareTo(UnityVersion other)


### PR DESCRIPTION
`?GameEngineVersion@PlatformWrapper@UnityEngine@@SAPEBDXZ` is not available on Unity 5.3 and lower.

`Application_Get_Custom_PropUnityVersion` might be a good candidate for the new regex symbol resolver, I wrote it the way I did to list out all the specific versions.

Unity 3.4 to 4.7
```
?Application_Get_Custom_PropUnityVersion@@YAPAUMonoString@@XZ
struct MonoString * __cdecl Application_Get_Custom_PropUnityVersion(void)
```
5.0 to 2019.4
```
Application_Get_Custom_PropUnityVersion@@YAPEAUMonoString@@XZ
struct MonoString * __cdecl Application_Get_Custom_PropUnityVersion(void)
```
Unity 2020.1 onwards
```
?Application_Get_Custom_PropUnityVersion@@YAPEAVScriptingBackendNativeStringPtrOpaque@@XZ
class ScriptingBackendNativeStringPtrOpaque * __cdecl Application_Get_Custom_PropUnityVersion(void)
```

Should `?GameEngineVersion@PlatformWrapper@UnityEngine@@SAPEBDXZ` continue to be used for versions 5.5 or later or completely replaced?

Should there be a separate class for resolving mono functions? I'm not sure if it will come up much.

Sidenote: I'm not a fan of manually escaping regex like in the example
```
resolver.ResolveFirstFunctionMatching<CStrDelegate>(new Regex(@"\?c_str@\?\$basic_string@*"));
``` 
I think this would be better
```
resolver.ResolveFirstFunctionMatching<CStrDelegate>(new Regex(Regex.Escape("?c_str@?$basic_string@") + "*")));
``` 