### PR TITLE
Add export support for Unity 4.0 to Unity 4.7

### DIFF
--- a/TypeTreeDumper/Dumper.cs
+++ b/TypeTreeDumper/Dumper.cs
@@ -15,7 +15,10 @@ namespace TypeTreeDumper
             OutputDirectory = outputDirectory;
             Console.WriteLine($"Starting export. UnityVersion {engine.Version}.");
             Directory.CreateDirectory(OutputDirectory);
-            ExportStringData(engine.CommonString);
+            if (engine.Version >= UnityVersion.Unity5_0)
+            {
+                ExportStringData(engine.CommonString);
+            }
             ExportClassesJson(engine.RuntimeTypes);
             ExportRTTI(engine.RuntimeTypes);
             ExportStructDump(engine);

--- a/Unity/DynamicArray.cs
+++ b/Unity/DynamicArray.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Unity
 {
@@ -10,12 +13,31 @@ namespace Unity
         public ulong Capacity;
     }
 
-    unsafe struct DynamicArray<T>
+    unsafe struct DynamicArray<T> : IReadOnlyList<T>
         where T : unmanaged
     {
         public T* Ptr;
         public MemLabelId Label;
         public ulong Size;
         public ulong Capacity;
+
+        public T this[int index] => Ptr[index];
+
+        public int Count => (int)Size;
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            var arr = new T[Count];
+            for(int i = 0; i < Count; i++)
+            {
+                arr[i] = Ptr[i];
+            }
+            return arr.AsEnumerable().GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
     }
 }

--- a/Unity/NativeObjectFactory.cs
+++ b/Unity/NativeObjectFactory.cs
@@ -64,12 +64,25 @@ namespace Unity
             this.resolver = resolver;
             if(HasGetSpriteAtlasDatabase) s_GetSpriteAtlasDatabase = resolver.ResolveFunction<GetSpriteAtlasDatabaseDelegate>("?GetSpriteAtlasDatabase@@YAAEAVSpriteAtlasDatabase@@XZ");
             if(HasGetSceneVisibilityState) s_GetSceneVisibilityState = resolver.ResolveFunction<GetSceneVisibilityStateDelegate>("?GetSceneVisibilityState@@YAAEAVSceneVisibilityState@@XZ");
-            resolver.TryResolveFunction("?GetInspectorExpandedState@@YAAEAVInspectorExpandedState@@XZ", out s_GetInspectorExpandedState);
-            resolver.TryResolveFunction("?GetAnnotationManager@@YAAEAVAnnotationManager@@XZ", out s_GetAnnotationManager);
-            s_GetMonoManager = resolver.ResolveFunction<GetMonoManagerDelegate>("?GetMonoManager@@YAAEAVMonoManager@@XZ", "?GetMonoManager@@YAAAVMonoManager@@XZ");
+            s_GetInspectorExpandedState = resolver.ResolveFunction<GetInspectorExpandedStateDelegate>(
+                "?GetInspectorExpandedState@@YAAEAVInspectorExpandedState@@XZ",
+                "?GetInspectorExpandedState@@YAAAVInspectorExpandedState@@XZ");
+            s_GetInspectorExpandedState = resolver.ResolveFunction<GetInspectorExpandedStateDelegate>(
+                "?GetInspectorExpandedState@@YAAEAVInspectorExpandedState@@XZ",
+                "?GetInspectorExpandedState@@YAAAVInspectorExpandedState@@XZ");
+            s_GetAnnotationManager = resolver.ResolveFunction<GetAnnotationManagerDelegate>(
+                "?GetAnnotationManager@@YAAEAVAnnotationManager@@XZ",
+                "?GetAnnotationManager@@YAAAVAnnotationManager@@XZ");
+            s_GetMonoManager = resolver.ResolveFunction<GetMonoManagerDelegate>(
+                "?GetMonoManager@@YAAEAVMonoManager@@XZ",
+                "?GetMonoManager@@YAAAVMonoManager@@XZ");
             if (version < UnityVersion.Unity5_5)
             {
-                s_ProduceV1 = resolver.ResolveFunction<ProduceDelegateV1>("?Produce@Object@@SAPEAV1@HHUMemLabelId@@W4ObjectCreationMode@@@Z", "?Produce@Object@@SAPAV1@HHUMemLabelId@@W4ObjectCreationMode@@@Z");
+                s_ProduceV1 = resolver.ResolveFunction<ProduceDelegateV1>(
+                    "?Produce@Object@@SAPEAV1@HHUMemLabelId@@W4ObjectCreationMode@@@Z",
+                    "?Produce@Object@@SAPAV1@HHUMemLabelId@@W4ObjectCreationMode@@@Z",
+                    "?Produce@Object@@SAPAV1@HHPAVBaseAllocator@@W4ObjectCreationMode@@@Z"
+                    );
             }
             else if(version < UnityVersion.Unity2017_2)
             {

--- a/Unity/TypeTree.V1.cs
+++ b/Unity/TypeTree.V1.cs
@@ -1,0 +1,136 @@
+﻿using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using ManagedTypeTree = Unity.TypeTree;
+using System;
+using System.Text.RegularExpressions;
+using System.Linq;
+
+namespace Unity
+{
+    public partial class TypeTree
+    {
+        unsafe class V1 : ITypeTreeImpl
+        {
+            [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+            delegate void TypeTreeDelegate(out TypeTree tree);
+
+            readonly CStrDelegate s_CStr;
+            [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+            unsafe delegate IntPtr CStrDelegate(ref TypeTreeString self);
+
+            internal TypeTree Tree;
+
+            public IReadOnlyList<byte> StringBuffer => m_StringBuffer;
+
+            public IReadOnlyList<TypeTreeNode> Nodes => m_Nodes;
+
+            private List<TypeTreeNode> m_Nodes;
+
+            private List<byte> m_StringBuffer;
+
+            private Dictionary<string, uint> m_StringBufferIndices;
+
+
+            public V1(ManagedTypeTree owner, SymbolResolver resolver)
+            {
+                var constructor = resolver.ResolveFunction<TypeTreeDelegate>("??0TypeTree@@QAE@XZ");
+                constructor.Invoke(out Tree);
+
+                s_CStr = resolver.ResolveFirstFunctionMatching<CStrDelegate>(
+                    new Regex(Regex.Escape("?c_str@?$basic_string@") + "*"));
+            }
+
+            public ref byte GetPinnableReference()
+            {
+                return ref Unsafe.As<TypeTree, byte>(ref Tree);
+            }
+
+            public void CreateNodes(ManagedTypeTree owner)
+            {
+                m_StringBuffer = new List<byte>();
+                m_StringBufferIndices = new Dictionary<string, uint>();
+                m_Nodes = new List<TypeTreeNode>();
+                CreateNodes(owner, ref m_Nodes, ref Tree);
+            }
+
+            public void CreateNodes(ManagedTypeTree owner, ref List<TypeTreeNode> nodes, ref TypeTree tree, int level = 0)
+            {
+                var typeIndex = GetOrCreateStringIndex(tree.m_Type);
+                var type = m_StringBufferIndices.First(kv => kv.Value == typeIndex).Key;
+                var nameIndex = GetOrCreateStringIndex(tree.m_Name);
+                var name = m_StringBufferIndices.First(kv => kv.Value == nameIndex).Key;
+                var nodeImpl = new TypeTreeNode.V1(
+                    version: (short)tree.m_Version,
+                    level: (byte)level,
+                    typeFlags: (TypeFlags)tree.m_IsArray,
+                    typeStrOffset: typeIndex,
+                    nameStrOffset: nameIndex,
+                    byteSize: tree.m_ByteSize,
+                    index: tree.m_Index,
+                    metaFlag: tree.m_MetaFlag);
+                nodes.Add(new TypeTreeNode(nodeImpl, owner));
+
+                var node = tree.m_Children.Head;
+                for(int i = 0; i < tree.m_Children.Size; i++)
+                {
+                    node = node->Next;
+                    var child = node->Value;
+                    CreateNodes(owner, ref nodes, ref child, level + 1);
+                }
+            }
+
+            uint GetOrCreateStringIndex(TypeTreeString typeTreeString)
+            {
+                var str = Marshal.PtrToStringAnsi(s_CStr(ref typeTreeString));
+                if (m_StringBufferIndices.TryGetValue(str, out var key))
+                {
+                    return key;
+                }
+                var newKey = (uint)m_StringBuffer.Count;
+                m_StringBufferIndices[str] = newKey;
+                foreach (byte b in str)
+                {
+                    m_StringBuffer.Add(b);
+                }
+                m_StringBuffer.Add(0);
+                return newKey;
+            }
+
+            internal struct TypeTreeString
+            {
+                fixed byte Data[28];
+            };
+
+            internal unsafe struct TypeTreeList
+            {
+                public TypeTreeListNode* Head;
+                public uint Size;
+                public int Padding1;
+                public int Padding2;
+            };
+
+            internal unsafe struct TypeTreeListNode
+            {
+                public TypeTreeListNode* Next;
+                public TypeTreeListNode* Prev;
+                public TypeTree Value;
+            }
+
+            internal struct TypeTree
+            {
+                public TypeTreeList m_Children;
+                public TypeTree* m_Father;
+                public TypeTreeString m_Type;
+                public TypeTreeString m_Name;
+                public int m_ByteSize;
+                public int m_Index;
+                public int m_IsArray;
+                public int m_Version;
+                public TransferMetaFlags m_MetaFlag;
+                public int m_ByteOffset;
+                public void* m_DirectPtr;
+            }
+        }
+    }
+}

--- a/Unity/TypeTree.V2019_1.cs
+++ b/Unity/TypeTree.V2019_1.cs
@@ -12,7 +12,7 @@ namespace Unity
         {
             internal TypeTree Tree;
 
-            public DynamicArray<byte> StringBuffer => Tree.Data->StringBuffer;
+            public IReadOnlyList<byte> StringBuffer => Tree.Data->StringBuffer;
 
             public IReadOnlyList<TypeTreeNode> Nodes => m_Nodes;
 

--- a/Unity/TypeTree.V2019_3.cs
+++ b/Unity/TypeTree.V2019_3.cs
@@ -13,7 +13,7 @@ namespace Unity
         {
             internal TypeTree Tree;
 
-            public DynamicArray<byte> StringBuffer => Tree.Data->StringBuffer;
+            public IReadOnlyList<byte> StringBuffer => Tree.Data->StringBuffer;
 
             public IReadOnlyList<TypeTreeNode> Nodes => m_Nodes;
 

--- a/Unity/TypeTree.V5_0.cs
+++ b/Unity/TypeTree.V5_0.cs
@@ -12,7 +12,7 @@ namespace Unity
         {
             internal TypeTree Tree;
 
-            public DynamicArray<byte> StringBuffer => Tree.StringBuffer;
+            public IReadOnlyList<byte> StringBuffer => Tree.StringBuffer;
 
             public IReadOnlyList<TypeTreeNode> Nodes => m_Nodes;
 
@@ -37,14 +37,14 @@ namespace Unity
                 var nodes = new TypeTreeNode[Tree.Nodes.Size];
 
                 for (int i = 0; i < nodes.Length; i++)
-                    nodes[i] = new TypeTreeNode(new TypeTreeNode.V1(Tree.Nodes.Ptr[i]), owner);
+                    nodes[i] = new TypeTreeNode(new TypeTreeNode.V5_0(Tree.Nodes.Ptr[i]), owner);
 
                 m_Nodes = nodes;
             }
 
             internal struct TypeTree
             {
-                public DynamicArray<TypeTreeNode.V1.TypeTreeNode> Nodes;
+                public DynamicArray<TypeTreeNode.V5_0.TypeTreeNode> Nodes;
                 public DynamicArray<byte> StringBuffer;
                 public DynamicArray<uint> ByteOffsets;
             }

--- a/Unity/TypeTree.V5_3.cs
+++ b/Unity/TypeTree.V5_3.cs
@@ -12,7 +12,7 @@ namespace Unity
         {
             internal TypeTree Tree;
 
-            public DynamicArray<byte> StringBuffer => Tree.StringBuffer;
+            public IReadOnlyList<byte> StringBuffer => Tree.StringBuffer;
 
             public IReadOnlyList<TypeTreeNode> Nodes => m_Nodes;
 
@@ -38,14 +38,14 @@ namespace Unity
                 var nodes = new TypeTreeNode[Tree.Nodes.Size];
 
                 for (int i = 0; i < nodes.Length; i++)
-                    nodes[i] = new TypeTreeNode(new TypeTreeNode.V1(Tree.Nodes.Ptr[i]), owner);
+                    nodes[i] = new TypeTreeNode(new TypeTreeNode.V5_0(Tree.Nodes.Ptr[i]), owner);
 
                 m_Nodes = nodes;
             }
 
             internal struct TypeTree
             {
-                public DynamicArray<TypeTreeNode.V1.TypeTreeNode> Nodes;
+                public DynamicArray<TypeTreeNode.V5_0.TypeTreeNode> Nodes;
                 public DynamicArray<byte> StringBuffer;
                 public DynamicArray<uint> ByteOffsets;
             }

--- a/Unity/TypeTreeNode.V1.cs
+++ b/Unity/TypeTreeNode.V1.cs
@@ -7,52 +7,45 @@ namespace Unity
     {
         internal unsafe class V1 : ITypeTreeNodeImpl
         {
-            internal TypeTreeNode Node;
+            public short Version { get; private set; }
 
-            public short Version => Node.Version;
+            public byte Level { get; private set; }
 
-            public byte Level => Node.Level;
+            public TypeFlags TypeFlags { get; private set; }
 
-            public TypeFlags TypeFlags => Node.TypeFlags;
+            public uint TypeStrOffset { get; private set; }
 
-            public uint TypeStrOffset => Node.TypeStrOffset;
+            public uint NameStrOffset { get; private set; }
 
-            public uint NameStrOffset => Node.NameStrOffset;
+            public int ByteSize { get; private set; }
 
-            public int ByteSize => Node.ByteSize;
+            public int Index { get; private set; }
 
-            public int Index => Node.Index;
+            public TransferMetaFlags MetaFlag { get; private set; }
 
-            public TransferMetaFlags MetaFlag => Node.MetaFlag;
-
-            internal V1(TypeTreeNode node)
+            internal V1(
+                short version,
+                byte level,
+                TypeFlags typeFlags,
+                uint typeStrOffset,
+                uint nameStrOffset,
+                int byteSize,
+                int index,
+                TransferMetaFlags metaFlag)
             {
-                Node = node;
-            }
-
-            public V1(IntPtr address)
-            {
-                if (address == IntPtr.Zero)
-                    throw new ArgumentNullException(nameof(address));
-
-                Node = *(TypeTreeNode*)address;
+                Version = version;
+                Level = level;
+                TypeFlags = typeFlags;
+                TypeStrOffset = typeStrOffset;
+                NameStrOffset = nameStrOffset;
+                ByteSize = byteSize;
+                Index = index;
+                MetaFlag = metaFlag;
             }
 
             public ref byte GetPinnableReference()
             {
-                return ref Unsafe.As<TypeTreeNode, byte>(ref Node);
-            }
-
-            internal struct TypeTreeNode
-            {
-                public short Version;
-                public byte Level;
-                public TypeFlags TypeFlags;
-                public uint TypeStrOffset;
-                public uint NameStrOffset;
-                public int ByteSize;
-                public int Index;
-                public TransferMetaFlags MetaFlag;
+                throw new NotImplementedException();
             }
         }
     }

--- a/Unity/TypeTreeNode.V5_0.cs
+++ b/Unity/TypeTreeNode.V5_0.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Unity
+{
+    public partial class TypeTreeNode
+    {
+        internal unsafe class V5_0 : ITypeTreeNodeImpl
+        {
+            internal TypeTreeNode Node;
+
+            public short Version => Node.Version;
+
+            public byte Level => Node.Level;
+
+            public TypeFlags TypeFlags => Node.TypeFlags;
+
+            public uint TypeStrOffset => Node.TypeStrOffset;
+
+            public uint NameStrOffset => Node.NameStrOffset;
+
+            public int ByteSize => Node.ByteSize;
+
+            public int Index => Node.Index;
+
+            public TransferMetaFlags MetaFlag => Node.MetaFlag;
+
+            internal V5_0(TypeTreeNode node)
+            {
+                Node = node;
+            }
+
+            public V5_0(IntPtr address)
+            {
+                if (address == IntPtr.Zero)
+                    throw new ArgumentNullException(nameof(address));
+
+                Node = *(TypeTreeNode*)address;
+            }
+
+            public ref byte GetPinnableReference()
+            {
+                return ref Unsafe.As<TypeTreeNode, byte>(ref Node);
+            }
+
+            internal struct TypeTreeNode
+            {
+                public short Version;
+                public byte Level;
+                public TypeFlags TypeFlags;
+                public uint TypeStrOffset;
+                public uint NameStrOffset;
+                public int ByteSize;
+                public int Index;
+                public TransferMetaFlags MetaFlag;
+            }
+        }
+    }
+}

--- a/Unity/TypeTreeNode.cs
+++ b/Unity/TypeTreeNode.cs
@@ -42,7 +42,7 @@ namespace Unity
             if (version >= UnityVersion.Unity2019_1)
                 node = new V2019_1(address);
             else
-                node = new V1(address);
+                node = new V5_0(address);
         }
 
         internal interface ITypeTreeNodeImpl


### PR DESCRIPTION
This method *should* also work with unity editor version 3.X, but I haven't tested it as the dumper is currently set up to work on the unity player for those versions. Adding player export support will require further changes as some symbols are missing and the layout of some classes has changed (such as MemLabel).