### PR TITLE
Add export support for unity 3.5

### DIFF
--- a/TypeTreeDumper.Bootstrapper/Program.cs
+++ b/TypeTreeDumper.Bootstrapper/Program.cs
@@ -25,6 +25,11 @@ namespace TypeTreeDumper
                 "-logFile", Path.Combine(Environment.CurrentDirectory, "Log.txt")
             };
 
+            if (version.FileMajorPart == 3)
+            {
+                commandLineArgs.Add("-executeMethod");
+                commandLineArgs.Add("Loader.Load");
+            }
             if (version.FileMajorPart >= 2018)
                 commandLineArgs.Add("-noUpm");
 

--- a/Unity/TypeTree.cs
+++ b/Unity/TypeTree.cs
@@ -12,8 +12,10 @@ namespace Unity
 
         public TypeTree(UnityVersion version, CommonString strings, SymbolResolver resolver)
         {
-            if (version < UnityVersion.Unity5_0)
+            if (version < UnityVersion.Unity4_0)
                 tree = new V1(this, resolver);
+            else if (version < UnityVersion.Unity5_0)
+                tree = new V4_0(this, resolver);
             else if (version < UnityVersion.Unity5_3)
                 tree = new V5_0(this, resolver);
             else if (version < UnityVersion.Unity2019_1)

--- a/Unity/UnityVersion.cs
+++ b/Unity/UnityVersion.cs
@@ -24,6 +24,26 @@ namespace Unity
 
         public readonly int Build;
 
+        public static readonly UnityVersion Unity3_4 = new UnityVersion(3, 4);
+
+        public static readonly UnityVersion Unity3_5 = new UnityVersion(3, 5);
+
+        public static readonly UnityVersion Unity4_0 = new UnityVersion(4, 0);
+
+        public static readonly UnityVersion Unity4_1 = new UnityVersion(4, 1);
+
+        public static readonly UnityVersion Unity4_2 = new UnityVersion(4, 2);
+
+        public static readonly UnityVersion Unity4_3 = new UnityVersion(4, 3);
+
+        public static readonly UnityVersion Unity4_4 = new UnityVersion(4, 4);
+
+        public static readonly UnityVersion Unity4_5 = new UnityVersion(4, 5);
+
+        public static readonly UnityVersion Unity4_6 = new UnityVersion(4, 6);
+
+        public static readonly UnityVersion Unity4_7 = new UnityVersion(4, 7);
+
         public static readonly UnityVersion Unity5_0 = new UnityVersion(5, 0);
 
         public static readonly UnityVersion Unity5_1 = new UnityVersion(5, 1);


### PR DESCRIPTION
The layout of the STL containers (TypeTreeString and TypeTreeList) differ between 3.5 and 4.0.
This PR does not support 3.4, as that version does not appear to have MemLabelIds. The signature for Object::Produce is 
```
Object * __cdecl Produce(int param_1, int param_2, BaseAllocator *param_3, ObjectCreationMode param_4)
```